### PR TITLE
Added mesh replacement and overlays

### DIFF
--- a/CustomWalls-Editor/Properties/AssemblyInfo.cs
+++ b/CustomWalls-Editor/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/CustomWalls/CustomWalls.csproj
+++ b/CustomWalls/CustomWalls.csproj
@@ -33,64 +33,64 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Libs\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BSML">
-      <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\BSML.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BS_Utils">
-      <HintPath>$(BeatSaberDir)\Plugins\BS_Utils.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\BS_Utils.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HMLib">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\HMLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HMRendering">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMRendering.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\HMRendering.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HMUI">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\HMUI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Main">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Main.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="IPA.Loader">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SemVer">
-      <HintPath>$(BeatSaberDir)\Libs\SemVer.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Libs\SemVer.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Unity.TextMeshPro">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -111,6 +111,7 @@
     <Compile Include="Settings\UI\SettingsUI.cs" />
     <Compile Include="Utilities\MaterialAssetLoader.cs" />
     <Compile Include="Utilities\MaterialUtils.cs" />
+    <Compile Include="Utilities\MeshUtils.cs" />
     <Compile Include="Utilities\Utils.cs" />
     <Compile Include="Utilities\ScoreUtility.cs" />
   </ItemGroup>
@@ -129,6 +130,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetPath)" "$(BeatSaberDir)\Plugins"</PostBuildEvent>
+    <PostBuildEvent>copy "$(TargetPath)" "C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/CustomWalls/CustomWalls.csproj
+++ b/CustomWalls/CustomWalls.csproj
@@ -33,64 +33,64 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Libs\0Harmony.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BSML">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\BSML.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BS_Utils">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\BS_Utils.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Plugins\BS_Utils.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HMLib">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\HMLib.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HMRendering">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\HMRendering.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMRendering.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HMUI">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\HMUI.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Main">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Main.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="IPA.Loader">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SemVer">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Libs\SemVer.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Libs\SemVer.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Unity.TextMeshPro">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -130,6 +130,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetPath)" "C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins"</PostBuildEvent>
+    <PostBuildEvent>copy "$(TargetPath)" "$(BeatSaberDir)\Plugins"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/CustomWalls/Data/CustomMaterial.cs
+++ b/CustomWalls/Data/CustomMaterial.cs
@@ -13,6 +13,7 @@ namespace CustomWalls.Data
         public MaterialDescriptor Descriptor { get; }
         public GameObject GameObject { get; }
         public Renderer MaterialRenderer { get; }
+        public MeshFilter MaterialMeshFilter { get; }
         public string ErrorMessage { get; } = string.Empty;
 
         public CustomMaterial(string fileName)
@@ -28,6 +29,7 @@ namespace CustomWalls.Data
                     GameObject = AssetBundle.LoadAsset<GameObject>("Assets/_CustomMaterial.prefab");
                     Descriptor = GameObject.GetComponent<MaterialDescriptor>();
                     MaterialRenderer = MaterialUtils.GetGameObjectRenderer(GameObject, "pixie");
+                    MaterialMeshFilter = MeshUtils.GetGameObjectMeshFilter(GameObject, "pixie");
                 }
                 catch (Exception ex)
                 {
@@ -74,6 +76,7 @@ namespace CustomWalls.Data
                     FileName = $@"internalResource\{name}";
                     Descriptor = GameObject.GetComponent<MaterialDescriptor>();
                     MaterialRenderer = MaterialUtils.GetGameObjectRenderer(GameObject, "pixie");
+                    MaterialMeshFilter = MeshUtils.GetGameObjectMeshFilter(GameObject, "pixie");
                 }
                 catch (Exception ex)
                 {

--- a/CustomWalls/Data/CustomMaterialExtensions/MaterialDescriptor.cs
+++ b/CustomWalls/Data/CustomMaterialExtensions/MaterialDescriptor.cs
@@ -7,6 +7,11 @@ namespace CustomWalls.Data.CustomMaterialExtensions
         public string AuthorName = "Wall Author";
         public string MaterialName = "Wall Name";
         public string Description = string.Empty;
+        public bool ReplaceMesh = false;
+        public float MeshScaleMultiplier = 1;
+        public bool Overlay = false;
+        public float OverlayOffset = .001f;
+        public bool ReplaceOnlyOverlayMesh = true;
         public bool DisablesScore = false;
         public Texture2D Icon;
     }

--- a/CustomWalls/HarmonyPatches/Patches/WallPatch.cs
+++ b/CustomWalls/HarmonyPatches/Patches/WallPatch.cs
@@ -23,8 +23,28 @@ namespace CustomWalls.HarmonyPatches.Patches
                 if (customMaterial.FileName != "DefaultMaterials")
                 {
                     Renderer mesh = __instance.gameObject.GetComponentInChildren<Renderer>();
-                    MaterialUtils.ReplaceRenderer(mesh, customMaterial.MaterialRenderer);
-                    MaterialUtils.SetMaterialsColor(mesh?.materials, MaterialUtils.CurrentColorManager.GetObstacleEffectColor());
+                    Color color = MaterialUtils.CurrentColorManager.GetObstacleEffectColor();
+                    if (customMaterial.Descriptor.Overlay)
+                    {
+                        GameObject overlay = MeshUtils.CreateOverlay(mesh, customMaterial.MaterialRenderer, customMaterial.Descriptor.OverlayOffset);
+                        MaterialUtils.SetMaterialsColor(overlay?.GetComponent<Renderer>().materials, color);
+                        if (customMaterial.Descriptor.ReplaceMesh) {
+                            MeshUtils.ReplaceMesh(overlay.GetComponent<MeshFilter>(), customMaterial.MaterialMeshFilter, customMaterial.Descriptor.MeshScaleMultiplier);
+                            if(!customMaterial.Descriptor.ReplaceOnlyOverlayMesh)
+                            {
+                                MeshUtils.ReplaceMesh(__instance.gameObject.GetComponentInChildren<MeshFilter>(), customMaterial.MaterialMeshFilter, customMaterial.Descriptor.MeshScaleMultiplier);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        MaterialUtils.ReplaceRenderer(mesh, customMaterial.MaterialRenderer);
+                        MaterialUtils.SetMaterialsColor(mesh?.materials, color);
+                        if (customMaterial.Descriptor.ReplaceMesh)
+                        {
+                            MeshUtils.ReplaceMesh(__instance.gameObject.GetComponentInChildren<MeshFilter>(), customMaterial.MaterialMeshFilter, customMaterial.Descriptor.MeshScaleMultiplier);
+                        }
+                    }
                 }
 
                 if (!Configuration.EnableObstacleFrame)

--- a/CustomWalls/Properties/AssemblyInfo.cs
+++ b/CustomWalls/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.3.1.0")]
-[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/CustomWalls/Utilities/MaterialUtils.cs
+++ b/CustomWalls/Utilities/MaterialUtils.cs
@@ -47,7 +47,6 @@ namespace CustomWalls.Utilities
         public static void ReplaceRenderer(Renderer target, Renderer donor)
         {
             target.material = donor.material;
-
             //int materialsLength = donor.materials.Length;
             //if (materialsLength > target.materials.Length)
             //{

--- a/CustomWalls/Utilities/MeshUtils.cs
+++ b/CustomWalls/Utilities/MeshUtils.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace CustomWalls.Utilities
+{
+    internal class MeshUtils
+    {
+        /// <summary>
+        /// Find a specific mesh filter within a GameObject
+        /// </summary>
+        /// <param name="gameObject">GameObject</param>
+        /// <param name="rendererName">Filter name</param>
+        public static MeshFilter GetGameObjectMeshFilter(GameObject gameObject, string filterName)
+        {
+            IEnumerable<MeshFilter> filters = GetGameObjectMeshFilter(gameObject);
+            foreach (MeshFilter filter in filters)
+            {
+                if (string.Equals(filter.name, filterName, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return filter;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Find all mesh filters within a GameObject
+        /// </summary>
+        /// <param name="gameObject">GameObject</param>
+        /// <param name="includeInactive">Include inactive filter</param>
+        public static IEnumerable<MeshFilter> GetGameObjectMeshFilter(GameObject gameObject, bool includeInactive = false)
+        {
+            IEnumerable<MeshFilter> filters = gameObject?.GetComponentsInChildren<MeshFilter>(includeInactive);
+            return filters ?? Enumerable.Empty<MeshFilter>();
+        }
+
+        /// <summary>
+        /// Creates a brand new object that overlays on top of the normal wall
+        /// </summary>
+        /// <param name="target"></param>
+        /// <param name="donor"></param>
+        /// <param name="offset"></param>
+        public static GameObject CreateOverlay(Renderer target, Renderer donor, float offset)
+        {
+            GameObject overlayObject = new GameObject("Overlay");
+            overlayObject.transform.parent = target.transform;
+            float wallScale = offset;
+            overlayObject.transform.localScale = new Vector3(
+                1 + wallScale * (1 / target.transform.lossyScale.x),
+                1 + wallScale * (1 / target.transform.lossyScale.y),
+                1 + wallScale * (1 / target.transform.lossyScale.z)
+            );
+            overlayObject.transform.localPosition = new Vector3(0, 0, 0);
+            overlayObject.transform.localRotation = Quaternion.Euler(0, 0, 0);
+            MeshRenderer overlayRenderer = overlayObject.AddComponent<MeshRenderer>();
+            overlayRenderer.material = donor.material;
+
+            MeshFilter overlayFilter = overlayObject.AddComponent<MeshFilter>();
+            overlayFilter.mesh = target.gameObject.GetComponent<MeshFilter>().mesh;
+
+            return overlayObject;
+        }
+
+        /// <summary>
+        /// Copy over the essential parts of the donor over to the target meshfilter
+        /// </summary>
+        /// <param name="target"></param>
+        /// <param name="donor"></param>
+        public static void ReplaceMesh(MeshFilter target, MeshFilter donor, float scale)
+        {
+            target.mesh = donor.mesh;
+            target.gameObject.transform.localScale *= scale;
+        }
+    }
+}

--- a/CustomWalls/manifest.json
+++ b/CustomWalls/manifest.json
@@ -5,10 +5,10 @@
     "#![CustomWalls.Resources.description.md]",
     "Change the all the materials!"
   ],
-  "gameVersion": "1.8.0",
+  "gameVersion": "1.11.0",
   "id": "CustomWalls",
   "name": "CustomWalls",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "dependsOn": {
     "BeatSaberMarkupLanguage": "^1.1.0",
     "BS Utils": "^1.4.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 CustomWalls allows you to customize the obstacle walls in Beat Saber
 
 ## Features
-* Replace the wall materials in Beat Saber
+* Replace the wall materials/mesh in Beat Saber
 * Disable the wall frame
 
 ## For developers


### PR DESCRIPTION
This adds the ability to replace meshes, which will make vertex displacement shaders actually reasonable to use (8 vertices is not nearly enough to manipulate stuff)

It also adds "overlay" walls, so that you can have a semitransparent addition while still keeping the original wall's shader.

The MaterialDescriptor is starting to get a bit cramped in editor, I'll submit a new pull request to the Unity project soon with the new DLL and a custom editor so that it's not as bad.