### PR TITLE
Updated for Beat Saber 1.13.2 and fixed a preview bug 

### DIFF
--- a/CustomWalls/Properties/AssemblyInfo.cs
+++ b/CustomWalls/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.5.1.0")]
-[assembly: AssemblyFileVersion("1.5.1.0")]
+[assembly: AssemblyVersion("1.5.2")]
+[assembly: AssemblyFileVersion("1.5.2")]

--- a/CustomWalls/Settings/UI/MaterialListViewController.cs
+++ b/CustomWalls/Settings/UI/MaterialListViewController.cs
@@ -135,6 +135,11 @@ namespace CustomWalls.Settings.UI
                     }
 
                     materialObject.transform.localScale = new Vector3(10f, 37.5f, 75f);
+                    if (customMaterial.Descriptor.ReplaceMesh)
+                    {
+                        // Account for custom mesh scale being weird in previews
+                        materialObject.transform.localScale *= 0.025f;
+                    }
 
                     Renderer renderer = materialObject.gameObject?.GetComponentInChildren<Renderer>();
                     MaterialUtils.SetMaterialsColor(renderer?.materials, colorManager.GetObstacleEffectColor());

--- a/CustomWalls/manifest.json
+++ b/CustomWalls/manifest.json
@@ -14,7 +14,6 @@
     "BeatSaberMarkupLanguage": "^1.3.5",
     "BS Utils": "^1.4.0"
   },
-  "features": [],
   "links": {
     "project-home": "https://github.com/Pespiri/",
     "project-source": "https://github.com/Pespiri/BeatSaberCustomWalls"

--- a/CustomWalls/manifest.json
+++ b/CustomWalls/manifest.json
@@ -5,10 +5,10 @@
     "#![CustomWalls.Resources.description.md]",
     "Change the all the materials!"
   ],
-  "gameVersion": "1.12.2",
+  "gameVersion": "1.13.2",
   "id": "CustomWalls",
   "name": "CustomWalls",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "dependsOn": {
     "BSIPA":  "^4.1.3",
     "BeatSaberMarkupLanguage": "^1.3.5",


### PR DESCRIPTION
A preview bug caused some walls with custom meshes to appear huge instead of normal sized. This PR should fix that.

Also version bumped to make it work with the latest Beat Saber update.